### PR TITLE
Requirement fixes for gensim

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-gensim
+gensim==3.8.1
 flask
 Flask-Bootstrap
 flask-cors
+scipy<1.13.0


### PR DESCRIPTION
Upgrades results in problem with gensim/scipy
ImportError: cannot import name 'triu' from 'scipy.linalg' AttributeError: The vocab attribute was removed from KeyedVector in Gensim 4.0.0. Downgrading scipy and fixing gensim version